### PR TITLE
chore: update Android NDK version to r28b in GitHub Actions workflow

### DIFF
--- a/.github/workflows/build-android-release.yml
+++ b/.github/workflows/build-android-release.yml
@@ -23,7 +23,7 @@ jobs:
       uses: nttld/setup-ndk@v1
       id: setup-ndk
       with:
-        ndk-version: 'r26d'
+        ndk-version: 'r28b'
         add-to-path: true
 
     - name: Set up environment variables


### PR DESCRIPTION
Support 16 KB page sizes